### PR TITLE
Timed Invulnerable Player Shield / Shield Pickup Items

### DIFF
--- a/Unity Files/Assets/Materials/ShieldMaterial.mat
+++ b/Unity Files/Assets/Materials/ShieldMaterial.mat
@@ -1,0 +1,67 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ShieldMaterial
+  m_Shader: {fileID: 4800000, guid: 4d4839e755cd0fe40a6e1059a4179983, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Amount: 4
+    - _EnableExternalAlpha: 0
+    - _FresnelExponent: 1
+    - _Intensity: 4.5
+    - _Ka: 0.2
+    - _Kd: 1
+    - _Ks: 1
+    - _Metallic: 0
+    - _Shininess: 32
+    - _Smoothness: 0
+    - _TimeScale: 1
+    - _ZWrite: 0
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Emission: {r: 0, g: 0, b: 0, a: 1}
+    - _FresnelColor: {r: 0, g: 0.7, b: 0.9, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Unity Files/Assets/Materials/ShieldMaterial.mat.meta
+++ b/Unity Files/Assets/Materials/ShieldMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7af3e021c7121e042aa987d794ab5822
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity Files/Assets/PreFabs/Player Suite.prefab
+++ b/Unity Files/Assets/PreFabs/Player Suite.prefab
@@ -2403,6 +2403,117 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4925603703823643628
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7830761965630641996}
+  - component: {fileID: 6690948233817391955}
+  - component: {fileID: 6931535041825267352}
+  - component: {fileID: 5213653617603358740}
+  m_Layer: 3
+  m_Name: PlayerShield
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7830761965630641996
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4925603703823643628}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.036, z: 0}
+  m_LocalScale: {x: 0.11298, y: 0.11298, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3529947247739330478}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6690948233817391955
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4925603703823643628}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6931535041825267352
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4925603703823643628}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7af3e021c7121e042aa987d794ab5822, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &5213653617603358740
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4925603703823643628}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5235877726572985229
 GameObject:
   m_ObjectHideFlags: 0
@@ -18978,7 +19089,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 15, y: 15, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 7830761965630641996}
   m_Father: {fileID: 2756179398824030747}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &9104103758114453206

--- a/Unity Files/Assets/PreFabs/shieldpickup_0.prefab
+++ b/Unity Files/Assets/PreFabs/shieldpickup_0.prefab
@@ -1,0 +1,168 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &739786769027011926
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4177539155482137347}
+  - component: {fileID: 6746797926576396080}
+  - component: {fileID: 3255242567447472947}
+  - component: {fileID: 7790948362210987237}
+  - component: {fileID: 1303779060511712039}
+  - component: {fileID: 4899281428246121086}
+  m_Layer: 0
+  m_Name: shieldpickup_0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4177539155482137347
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739786769027011926}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 12.94, y: 7.1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6746797926576396080
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739786769027011926}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3255242567447472947
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739786769027011926}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7af3e021c7121e042aa987d794ab5822, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &7790948362210987237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739786769027011926}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 546105e640262a74cb5e42204c696e37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::ItemHover
+  animDist: 0.5
+  animDur: 3
+--- !u!114 &1303779060511712039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739786769027011926}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4c57a31f6a598947ab31ff83b2cc23b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::ShieldPickup
+  shieldObject: {fileID: 0}
+  dur: 7
+--- !u!61 &4899281428246121086
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739786769027011926}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Unity Files/Assets/PreFabs/shieldpickup_0.prefab.meta
+++ b/Unity Files/Assets/PreFabs/shieldpickup_0.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 829c8422eeced654aae34847639848c0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity Files/Assets/Scripts/PlayerInvul.cs
+++ b/Unity Files/Assets/Scripts/PlayerInvul.cs
@@ -40,6 +40,15 @@ public class PlayerInvulnerability : MonoBehaviour
         StartCoroutine(InvulnerabilityRoutine());
     }
 
+    public void TriggerInvulnerabilityPermaOn()
+    {
+        invulnerable = true;
+    }
+    public void TriggerInvulnerabilityPermaOff()
+    {
+        invulnerable = false;
+    }
+
     IEnumerator InvulnerabilityRoutine()
     {
         if (playerSpriteRenderer == null) yield break;

--- a/Unity Files/Assets/Scripts/ShieldPickup.cs
+++ b/Unity Files/Assets/Scripts/ShieldPickup.cs
@@ -4,7 +4,9 @@ using System.Collections;
 public class ShieldPickup : MonoBehaviour
 {
     [SerializeField] private GameObject shieldObject;
-    [SerializeField] private float dur = 7f;
+    [SerializeField] private float dur = 8f;
+
+    private PlayerInvulnerability invuln;
 
 
     void OnTriggerEnter2D(Collider2D collision)
@@ -13,6 +15,10 @@ public class ShieldPickup : MonoBehaviour
 
         if (collision.CompareTag("Player"))
         {
+
+            invuln = collision.GetComponent<PlayerInvulnerability>();
+            invuln.TriggerInvulnerabilityPermaOn();
+
 
             shieldObject.SetActive(true);
 
@@ -33,6 +39,7 @@ public class ShieldPickup : MonoBehaviour
         yield return new WaitForSeconds(dur);
         gameObject.SetActive(false);
         shieldObject.SetActive(false);
+        invuln.TriggerInvulnerabilityPermaOff();
     }
 
     void Start()

--- a/Unity Files/Assets/Scripts/ShieldPickup.cs
+++ b/Unity Files/Assets/Scripts/ShieldPickup.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+using System.Collections;
+
+public class ShieldPickup : MonoBehaviour
+{
+    [SerializeField] private GameObject shieldObject;
+    [SerializeField] private float dur = 7f;
+
+
+    void OnTriggerEnter2D(Collider2D collision)
+    {
+
+
+        if (collision.CompareTag("Player"))
+        {
+            
+            shieldObject.SetActive(true);
+
+            GetComponent<MeshRenderer>().enabled = false;
+            GetComponent<Collider2D>().enabled = false;
+
+            StartCoroutine(ShieldTimer());
+
+
+
+
+        }
+    }
+
+    IEnumerator ShieldTimer()
+    {
+        
+        yield return new WaitForSeconds(dur);
+        gameObject.SetActive(false);
+        shieldObject.SetActive(false);
+    }
+
+    void Start()
+    {
+
+    }
+
+    void Update()
+    {
+
+    }
+}

--- a/Unity Files/Assets/Scripts/ShieldPickup.cs
+++ b/Unity Files/Assets/Scripts/ShieldPickup.cs
@@ -13,7 +13,7 @@ public class ShieldPickup : MonoBehaviour
 
         if (collision.CompareTag("Player"))
         {
-            
+
             shieldObject.SetActive(true);
 
             GetComponent<MeshRenderer>().enabled = false;
@@ -29,7 +29,7 @@ public class ShieldPickup : MonoBehaviour
 
     IEnumerator ShieldTimer()
     {
-        
+
         yield return new WaitForSeconds(dur);
         gameObject.SetActive(false);
         shieldObject.SetActive(false);

--- a/Unity Files/Assets/Scripts/ShieldPickup.cs.meta
+++ b/Unity Files/Assets/Scripts/ShieldPickup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4c57a31f6a598947ab31ff83b2cc23b

--- a/Unity Files/Assets/Shaders/Shield.shader
+++ b/Unity Files/Assets/Shaders/Shield.shader
@@ -3,11 +3,7 @@ Shader "Custom/Shield"
     Properties
     {
         _MainTex ("Texture", 2D) = "white" {}
-        _Ka ("Ambient", Float) = 0.2
-        _Kd ("Diffuse", Float) = 1.0
-        _Ks ("Specular", Float) = 1.0
-        _Shininess ("Shininess", Float) = 32
-        _TimeScale ("Time", Float) = 1.0
+
     }
 
     SubShader
@@ -25,7 +21,6 @@ Shader "Custom/Shield"
             #include "UnityCG.cginc"
 
             sampler2D _MainTex;
-            float _Ka, _Kd, _Ks, _Shininess, _TimeScale;
 
             struct appdata
             {
@@ -34,7 +29,7 @@ Shader "Custom/Shield"
                 float2 uv : TEXCOORD0;
             };
 
-            struct v2f
+            struct cords
             {
                 float4 pos : SV_POSITION;
                 float3 worldNormal : TEXCOORD0;
@@ -42,9 +37,9 @@ Shader "Custom/Shield"
                 float2 uv : TEXCOORD2;
             };
 
-            v2f vert(appdata v)
+            cords vert(appdata v)
             {
-                v2f o;
+                cords o;
                 o.pos = UnityObjectToClipPos(v.vertex);
                 o.worldNormal = UnityObjectToWorldNormal(v.normal);
 
@@ -53,48 +48,33 @@ Shader "Custom/Shield"
                 return o;
             }
 
-            float3 Fresnel(float3 N, float3 V)
+            float ShieldGlow(float3 VN, float3 VE)
             {
-                float R0 = 0.14;
-                float cosTheta = saturate(dot(V, N));
-                float R = R0 + (1.0 - R0) * pow(1.0 - cosTheta, 5.0);
-                return R;
+                float bias = 0.04;
+                float scale = 2.0;
+                float power = 2.8;
+                return bias + scale * pow(1.0 - saturate(dot(VE, VN)), power);
             }
 
-            fixed4 frag(v2f i) : SV_Target
+            fixed4 frag(cords i) : SV_Target
             {
-                float3 N = normalize(i.worldNormal);
-                float3 V = normalize(_WorldSpaceCameraPos - i.worldPos);
-                float3 L = normalize(_WorldSpaceLightPos0.xyz);
+                float3 VN = normalize(i.worldNormal);
+                float3 VE = float3(0, 0, -1);
 
     
-                float fresnel = Fresnel(N, V);
+                float fresnel = saturate(ShieldGlow(VN, VE));
+              //  float facing = step(0.0, dot(VN, VE));
+              //  fresnel *= facing;
 
-                float3 fresnelColor = float3(0.0, 0.7, 0.9);
-                float3 baseColor = float3(0.5, 0.2, 0.9);
+                float3 borderColor = float3(0.0, 0.68, 0.92);
 
-                float3 shield = fresnelColor * fresnel;
+                float3 mainColor = float3(0.1, 0.3, 0.92);
+
+                float3 shield = mainColor + borderColor * fresnel;
 
 
-                float2 uv = i.uv * 25.0;
-                float2 grid = frac(uv) - 0.5;
-  
 
-                float NdotL = saturate(dot(N, L));
-                float3 diffuse = _Kd * NdotL * baseColor;
-                float3 ambient = _Ka * baseColor;
-
-                float3 R = reflect(-L, N);
-                float spec = pow(saturate(dot(R, V)), _Shininess);
-                float3 specular = _Ks * spec * float3(1,1,1);
-
-                float3 finalColor =
-                    ambient +
-                    diffuse +
-                    specular +
-                    shield;
-
-                return float4(finalColor, fresnel);
+                return float4(shield, fresnel);
             }
 
             ENDCG

--- a/Unity Files/Assets/Shaders/Shield.shader
+++ b/Unity Files/Assets/Shaders/Shield.shader
@@ -1,0 +1,103 @@
+Shader "Custom/Shield"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _Ka ("Ambient", Float) = 0.2
+        _Kd ("Diffuse", Float) = 1.0
+        _Ks ("Specular", Float) = 1.0
+        _Shininess ("Shininess", Float) = 32
+        _TimeScale ("Time", Float) = 1.0
+    }
+
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Blend SrcAlpha OneMinusSrcAlpha
+        ZWrite Off
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            sampler2D _MainTex;
+            float _Ka, _Kd, _Ks, _Shininess, _TimeScale;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float3 worldNormal : TEXCOORD0;
+                float3 worldPos : TEXCOORD1;
+                float2 uv : TEXCOORD2;
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.worldNormal = UnityObjectToWorldNormal(v.normal);
+
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                o.uv = v.uv;
+                return o;
+            }
+
+            float3 Fresnel(float3 N, float3 V)
+            {
+                float R0 = 0.14;
+                float cosTheta = saturate(dot(V, N));
+                float R = R0 + (1.0 - R0) * pow(1.0 - cosTheta, 5.0);
+                return R;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float3 N = normalize(i.worldNormal);
+                float3 V = normalize(_WorldSpaceCameraPos - i.worldPos);
+                float3 L = normalize(_WorldSpaceLightPos0.xyz);
+
+    
+                float fresnel = Fresnel(N, V);
+
+                float3 fresnelColor = float3(0.0, 0.7, 0.9);
+                float3 baseColor = float3(0.5, 0.2, 0.9);
+
+                float3 shield = fresnelColor * fresnel;
+
+
+                float2 uv = i.uv * 25.0;
+                float2 grid = frac(uv) - 0.5;
+  
+
+                float NdotL = saturate(dot(N, L));
+                float3 diffuse = _Kd * NdotL * baseColor;
+                float3 ambient = _Ka * baseColor;
+
+                float3 R = reflect(-L, N);
+                float spec = pow(saturate(dot(R, V)), _Shininess);
+                float3 specular = _Ks * spec * float3(1,1,1);
+
+                float3 finalColor =
+                    ambient +
+                    diffuse +
+                    specular +
+                    shield;
+
+                return float4(finalColor, fresnel);
+            }
+
+            ENDCG
+        }
+    }
+}

--- a/Unity Files/Assets/Shaders/Shield.shader.meta
+++ b/Unity Files/Assets/Shaders/Shield.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4d4839e755cd0fe40a6e1059a4179983
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Summary: Added a shield that the player can pickup, granting invulnerability. Currently set to a timer for 8 seconds.

### Details:
Added 3 shield pickup items to level 1
Added a player shield as a child class of the player sprite object
Grants invulnerability for a set duration.
Shader is made using C# with UnityCG

### Files Changed:
ShieldMaterial.mat
Player Suite.prefab
shieldpickup_0.prefab
level1.unity
PlayerInvul.cs
Shield.shader

### Other info: 
Easiest testable location: after the second green bounce ball, in the air.
Another is placed in the middle of the map
Last one is in the bottom right of the map

Duration is changeable in the inspector on each shield object.
Hooks up to current invul mechanics, added toggle on and off options to invuln.


### Checklist
- [x] The program compiles and runs
- [x] The program is free of bugs (to your knowledge)
- [x] Changes are properly documented (comments, etc)
- [ ] Someone has been contacted to review changes
