### PR TITLE
Hitbox updates + bug fixing

### DIFF
--- a/Unity Files/Assets/PreFabs/Player Suite.prefab
+++ b/Unity Files/Assets/PreFabs/Player Suite.prefab
@@ -20929,7 +20929,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 897ee4f46cad8664da98807427e88c2c, type: 2}
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -21314,6 +21314,9 @@ MonoBehaviour:
   flurryOverlay: {fileID: 2602751678071334709}
   flurryText: {fileID: 4428469897358217108}
   mat: {fileID: 2100000, guid: 897ee4f46cad8664da98807427e88c2c, type: 2}
+  playerSpriteRenderer: {fileID: 9104103758114453206}
+  defaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  chargeMaterial: {fileID: 2100000, guid: 897ee4f46cad8664da98807427e88c2c, type: 2}
 --- !u!114 &1505741492486227703
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Unity Files/Assets/Scripts/HitScript.cs
+++ b/Unity Files/Assets/Scripts/HitScript.cs
@@ -6,57 +6,108 @@ public class HitScript : MonoBehaviour
     public float damageAmount = 25f;
     private float mainSceneIndex;
 
+    [Header("Downward Attack / Pogo")]
+    public bool isDownwardAttack = false;
+    public PlayerController player;
+    public float pogoStrength = 14f;
+
     private void OnTriggerEnter2D(Collider2D collision)
     {
+        // =========================
+        // ENEMIES
+        // =========================
+
         if (collision.CompareTag("Enemy"))
         {
             EnemySlap slapEnemy = collision.GetComponentInParent<EnemySlap>();
             if (slapEnemy != null)
             {
                 slapEnemy.EnemyTakeDamage(damageAmount);
+                ApplyPogo();
             }
 
             EnemyDefault defaultEnemy = collision.GetComponentInParent<EnemyDefault>();
             if (defaultEnemy != null)
             {
                 defaultEnemy.EnemyTakeDamage(damageAmount);
+                ApplyPogo();
             }
         }
 
+        // =========================
+        // START BUTTON
+        // =========================
 
-
-        // for start screen
         if (collision.CompareTag("StartButton"))
         {
             mainSceneIndex = SceneManager.GetActiveScene().buildIndex;
-            SceneManager.LoadScene(1); //should be the first level?
+            SceneManager.LoadScene(1);
         }
+
+        // =========================
+        // TUTORIAL TEXT
+        // =========================
+
         if (collision.CompareTag("Text"))
         {
             TutorialTrigger trigger = collision.GetComponent<TutorialTrigger>();
+
             if (trigger != null)
             {
                 trigger.Trigger();
             }
         }
 
+        // =========================
+        // TUTORIAL RAT
+        // =========================
+
         TutorialRat rat = collision.GetComponent<TutorialRat>();
+
         if (rat != null)
         {
             rat.OnHit();
+            ApplyPogo();
         }
 
+        // =========================
+        // BOSSES
+        // =========================
 
         FlyBoss boss = collision.GetComponent<FlyBoss>();
+
         if (boss != null)
         {
             boss.BossTakeDamage(damageAmount);
+            ApplyPogo();
         }
 
         BearBoss bearBoss = collision.GetComponent<BearBoss>();
+
         if (bearBoss != null)
+        {
             bearBoss.BossTakeDamage(damageAmount);
+            ApplyPogo();
+        }
+    }
 
+    void ApplyPogo()
+    {
+        // only apply pogo if this hitbox was spawned as a downward attack
+        if (isDownwardAttack && player != null)
+        {
+            Rigidbody2D rb = player.GetComponent<Rigidbody2D>();
 
+            if (rb != null)
+            {
+                // only pogo while falling downward
+                if (rb.linearVelocity.y <= 0)
+                {
+                    Vector2 vel = rb.linearVelocity;
+                    vel.y = pogoStrength;
+                    rb.linearVelocity = vel;
+                }
+            }
+        }
     }
 }

--- a/Unity Files/Assets/Scripts/PlayerAttack.cs
+++ b/Unity Files/Assets/Scripts/PlayerAttack.cs
@@ -120,9 +120,9 @@ public class PlayerAttack : MonoBehaviour
         {
             mat.SetFloat("_Charge", 1f);
 
-            SpawnAttack(facingDirection);
+            StartCoroutine(FlurryAttack(facingDirection));
             flurryTimer = 0f;
-            anim.SetTrigger("PlayerAttackFlurry");
+            anim.SetTrigger("PlayerAttackFlurry"); ;
 
             ChargeTime = 0f;
         }
@@ -183,6 +183,19 @@ public class PlayerAttack : MonoBehaviour
         }
 
         Destroy(hitbox, attackDuration);
+    }
+
+    System.Collections.IEnumerator FlurryAttack(Vector2 facingDirection)
+    {
+        int hitCount = 3;
+        float delay = 0.08f;
+
+        for (int i = 0; i < hitCount; i++)
+        {
+            SpawnAttack(facingDirection);
+
+            yield return new WaitForSeconds(delay);
+        }
     }
 
     void UpdateCooldownUI(Image overlay, Text text, float timer)

--- a/Unity Files/Assets/Scripts/PlayerAttack.cs
+++ b/Unity Files/Assets/Scripts/PlayerAttack.cs
@@ -33,6 +33,12 @@ public class PlayerAttack : MonoBehaviour
     public Material mat;
     private bool isCharging = false;
 
+    [Header("Materials")]
+    public SpriteRenderer playerSpriteRenderer;
+
+    public Material defaultMaterial;
+    public Material chargeMaterial;
+
     //private SpriteRenderer sr;
     //private Material mat;
 
@@ -101,6 +107,8 @@ public class PlayerAttack : MonoBehaviour
         // ======================
         if (Input.GetButton("AttackFlurry") && flurryTimer >= attackCooldown)
         {
+            // change material
+            playerSpriteRenderer.material = chargeMaterial;
             mat.SetFloat("_Charge", 1f);
             ChargeTime += Time.deltaTime;
 
@@ -125,12 +133,14 @@ public class PlayerAttack : MonoBehaviour
             anim.SetTrigger("PlayerAttackFlurry"); ;
 
             ChargeTime = 0f;
+            playerSpriteRenderer.material = defaultMaterial;
         }
         if (Input.GetButtonUp("AttackFlurry") && ChargeTime < TotalChargeTime)
         {
             mat.SetFloat("_Charge", 0f);
             mat.SetFloat("_FullyCharged", 0f);
             ChargeTime = 0f;
+            playerSpriteRenderer.material = defaultMaterial;
         }
 
         // ======================

--- a/Unity Files/Assets/Scripts/PlayerAttack.cs
+++ b/Unity Files/Assets/Scripts/PlayerAttack.cs
@@ -39,6 +39,7 @@ public class PlayerAttack : MonoBehaviour
     private float TotalChargeTime = 1f;
     private float ChargeTime = 0f;
 
+
     void Awake()
     {
         // sr = GetComponent<SpriteRenderer>();
@@ -63,9 +64,9 @@ public class PlayerAttack : MonoBehaviour
         if (Input.GetButton("Attack") && attackTimer >= attackCooldown)
         {
             //DOWWNWARDS ATTACK
-            if (Input.GetAxisRaw("UpDown") < -0.5f)
+            if (Input.GetAxisRaw("UpDown") < -0.5f) 
             {
-                SpawnAttack(facingDirection);
+                SpawnAttack(facingDirection, true);
                 attackTimer = 0f;
                 anim.SetTrigger("PlayerAttackDown");
             }
@@ -140,22 +141,40 @@ public class PlayerAttack : MonoBehaviour
         UpdateCooldownUI(flurryOverlay, flurryText, flurryTimer);
     }
 
-    void SpawnAttack(Vector2 facingDirection)
+    void SpawnAttack(Vector2 facingDirection, bool downwardAttack = false)
     {
-        Vector3 spawnPos = transform.position + (Vector3)(facingDirection * attackDistance);
+        Vector3 spawnPos;
+
+        if (downwardAttack)
+        {
+            // spawn BELOW player
+            spawnPos = transform.position + Vector3.down * attackDistance;
+        }
+        else
+        {
+            // normal side attack
+            spawnPos = transform.position + (Vector3)(facingDirection * attackDistance);
+        }
 
         GameObject hitbox = Instantiate(hitboxPrefab, spawnPos, Quaternion.identity);
         hitbox.transform.SetParent(transform);
 
         // flip hitbox if facing left
-        if (!playerController.isFacingRight)
+        if (!playerController.isFacingRight && !downwardAttack)
         {
             Vector3 scale = hitbox.transform.localScale;
             scale.x *= -1f;
             hitbox.transform.localScale = scale;
         }
 
-        // match player velocity
+        // pass downward flag into hitbox
+        HitScript hit = hitbox.GetComponent<HitScript>();
+        if (hit != null)
+        {
+            hit.isDownwardAttack = downwardAttack;
+            hit.player = playerController;
+        }
+
         Rigidbody2D rb = hitbox.GetComponent<Rigidbody2D>();
         if (rb != null)
         {

--- a/Unity Files/Assets/Scripts/PlayerInvul.cs
+++ b/Unity Files/Assets/Scripts/PlayerInvul.cs
@@ -61,6 +61,8 @@ public class PlayerInvulnerability : MonoBehaviour
 
         invulnerable = true;
 
+        Debug.Log("FLASHING: " + playerSpriteRenderer.name);
+
         float flashInterval = duration / (flashCount * 2f);
 
         for (int i = 0; i < flashCount; i++)


### PR DESCRIPTION
### Summary:
Made a few updates to hitboxes as well as fixing the issue where the flash feedback was no longer working. This addresses issues #94 and #97 
### Details:
- Downward attack now has properly spawning hitbox below the player
- Landing an attack on an enemy below the player now applies a "pogo" effect similar to in Hollow Knight
-- This also refreshes the players jump as far as I can tell... Can adjust this later but could be fun!
- Flurry attack now rapidly spawns a few hitboxes to simulate a multi-hit attack 
- PlayerSprite's Sprite Renderer material has been reverted to Sprites-Default. The render material swaps to ChargeMaterial while the flurry is being charged and reverts on release.
### Files Changed:
- HitScript.cs
- PlayerAttack.cs
- PlayerInvul.cs
- PlayerSuite prefab
### Other info: 
- Not sure what happened at the bottom of this review with like a million check boxes. Leaving because it's funny
### Checklist
- [x] The program compiles and runs
- [x] The program is free of bugs (to your knowledge)
- [x] Changes are properly documented (comments, etc)
- [ ] Someone has been contacted to review changes
- [x] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 