### PR TITLE
Shuriken nerf + Tutorial additions

### DIFF
--- a/Unity Files/Assets/PreFabs/Player Suite.prefab
+++ b/Unity Files/Assets/PreFabs/Player Suite.prefab
@@ -3458,6 +3458,7 @@ RectTransform:
   - {fileID: 2360631061363634998}
   - {fileID: 106321805777566493}
   - {fileID: 1373078544986035244}
+  - {fileID: 3054591566402572837}
   m_Father: {fileID: 6979447784804715226}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -20055,6 +20056,85 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7134677254226296072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3054591566402572837}
+  - component: {fileID: 8725380240834685646}
+  - component: {fileID: 1401180119893491924}
+  m_Layer: 5
+  m_Name: ShuriCount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3054591566402572837
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7134677254226296072}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9027633970054069107}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 33, y: -36.7}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8725380240834685646
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7134677254226296072}
+  m_CullTransparentMesh: 1
+--- !u!114 &1401180119893491924
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7134677254226296072}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
 --- !u!1 &7258896434043922430
 GameObject:
   m_ObjectHideFlags: 0
@@ -21404,6 +21484,8 @@ MonoBehaviour:
   cooldownOverlay: {fileID: 8897648967574985794}
   cooldownText: {fileID: 6372803333690083642}
   playerController: {fileID: 6654558692795548727}
+  shuriCount: 3
+  shuriCountText: {fileID: 1401180119893491924}
 --- !u!1 &8538718023124776878
 GameObject:
   m_ObjectHideFlags: 0

--- a/Unity Files/Assets/PreFabs/shuriAmmo.prefab
+++ b/Unity Files/Assets/PreFabs/shuriAmmo.prefab
@@ -1,0 +1,167 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2228462406216399284
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 203399843156028958}
+  - component: {fileID: 1153536257448787504}
+  - component: {fileID: 6519139147494127692}
+  - component: {fileID: -1558397731498570350}
+  - component: {fileID: -4787175349799201049}
+  m_Layer: 0
+  m_Name: shuriAmmo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &203399843156028958
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2228462406216399284}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -41.45, y: -3.44, z: 0}
+  m_LocalScale: {x: 12, y: 12, z: 0.2294}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1153536257448787504
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2228462406216399284}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2845445929213920030, guid: 1bad689f3ab79994a8baefccfc629f73, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 6.1, y: 5.46}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &6519139147494127692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2228462406216399284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 546105e640262a74cb5e42204c696e37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: GameScripts::ItemHover
+  animDist: 0.5
+  animDur: 3
+--- !u!61 &-1558397731498570350
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2228462406216399284}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.07954545, y: 0.07954545}
+    newSize: {x: 6.1, y: 5.46}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.1, y: 0.1}
+  m_EdgeRadius: 0
+--- !u!114 &-4787175349799201049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2228462406216399284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad298e09647bd994fa797ba237dc3b8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'

--- a/Unity Files/Assets/PreFabs/shuriAmmo.prefab.meta
+++ b/Unity Files/Assets/PreFabs/shuriAmmo.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a87d4da4339daa64ea28e19be88c28fb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity Files/Assets/Scenes/Desert.unity
+++ b/Unity Files/Assets/Scenes/Desert.unity
@@ -252048,6 +252048,63 @@ Transform:
   - {fileID: 1765195916}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1028560212
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -93.39421
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -136.45639
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
 --- !u!1001 &1042884522
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -259461,6 +259518,63 @@ MonoBehaviour:
   launchCooldown: 0.4
   jumpForce: 10
   jumpInterval: 5
+--- !u!1001 &1759332718
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 96.64949
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -67.99505
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
 --- !u!1 &1761625732 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -2253911629886400664, guid: 24dab801b2e7f6042bc3c439154dd267, type: 3}
@@ -262393,6 +262507,63 @@ Camera:
   m_CorrespondingSourceObject: {fileID: 9053328931184322162, guid: 73a9ed35e31d3574fbeb4db98f30fb1e, type: 3}
   m_PrefabInstance: {fileID: 2049815040}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2083460116
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 134.00226
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -35.104816
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
 --- !u!1 &2083473803
 GameObject:
   m_ObjectHideFlags: 0
@@ -262804,3 +262975,6 @@ SceneRoots:
   - {fileID: 1542708000}
   - {fileID: 33287632}
   - {fileID: 1915887522}
+  - {fileID: 2083460116}
+  - {fileID: 1028560212}
+  - {fileID: 1759332718}

--- a/Unity Files/Assets/Scenes/Forrest.unity
+++ b/Unity Files/Assets/Scenes/Forrest.unity
@@ -32948,6 +32948,63 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 530782864}
   m_SourcePrefab: {fileID: -8435245712485981826, guid: 517025ed82d0a63458ce6228c28d00ed, type: 3}
+--- !u!1001 &1197240681
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 206.913
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.2842293
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
 --- !u!1 &1199947322 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -2253911629886400664, guid: ce1ac1e11d62ce541b0e649928785bdd, type: 3}
@@ -39610,6 +39667,63 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 696818675}
   m_SourcePrefab: {fileID: -8435245712485981826, guid: 5db1d8be565f20b419f975318937f06d, type: 3}
+--- !u!1001 &1724194765
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 123.473145
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18.989683
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
 --- !u!1 &1739472304 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -2253911629886400664, guid: 517025ed82d0a63458ce6228c28d00ed, type: 3}
@@ -40584,6 +40698,63 @@ MonoBehaviour:
   setStartPositionOnAwake: 1
   damageAmount: 25
   enemyHealth: 50
+--- !u!1001 &1781104563
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 206.59785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.504827
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046036958284113223, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5301394207634200113, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
+      propertyPath: m_Name
+      value: HP Pickup
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f8b5663622aa19f40b59307efef0d7cc, type: 3}
 --- !u!1 &1782241394 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -2253911629886400664, guid: ce1ac1e11d62ce541b0e649928785bdd, type: 3}
@@ -80696,3 +80867,6 @@ SceneRoots:
   - {fileID: 811691093}
   - {fileID: 1719959888}
   - {fileID: 1668115395}
+  - {fileID: 1781104563}
+  - {fileID: 1197240681}
+  - {fileID: 1724194765}

--- a/Unity Files/Assets/Scenes/level1.unity
+++ b/Unity Files/Assets/Scenes/level1.unity
@@ -169705,6 +169705,120 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cf96640fff222374f8cebf3c1dc710ea, type: 3}
+--- !u!1001 &1732417908
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 240.22632
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 21.436676
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+--- !u!1001 &1802047664
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 124.254166
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.45164
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 203399843156028958, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2228462406216399284, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
+      propertyPath: m_Name
+      value: shuriAmmo (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a87d4da4339daa64ea28e19be88c28fb, type: 3}
 --- !u!1 &1827543121
 GameObject:
   m_ObjectHideFlags: 0
@@ -170803,3 +170917,5 @@ SceneRoots:
   - {fileID: 1156043273}
   - {fileID: 206953365}
   - {fileID: 1516084676}
+  - {fileID: 1732417908}
+  - {fileID: 1802047664}

--- a/Unity Files/Assets/Scripts/ShuriPickup.cs
+++ b/Unity Files/Assets/Scripts/ShuriPickup.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+public class ShuriPickup : MonoBehaviour
+{
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+
+    void OnTriggerEnter2D(Collider2D collision)
+    {
+
+        if (collision.CompareTag("Player"))
+        {
+
+            //preventDuplicate = true;
+
+            Destroy(gameObject);
+
+            PlayerShuriken player = collision.GetComponentInParent<PlayerShuriken>();
+
+            player.shuriCount = 3;
+
+
+
+
+
+
+
+
+        }
+    }
+
+}

--- a/Unity Files/Assets/Scripts/ShuriPickup.cs.meta
+++ b/Unity Files/Assets/Scripts/ShuriPickup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad298e09647bd994fa797ba237dc3b8f

--- a/Unity Files/Assets/Scripts/ThrowShuri.cs
+++ b/Unity Files/Assets/Scripts/ThrowShuri.cs
@@ -18,14 +18,20 @@ public class PlayerShuriken : MonoBehaviour
     [Header("References")]
     public PlayerController playerController;
 
+    [Header("Inventory")]
+    public int shuriCount = 3;
+    public Text shuriCountText;
+
     void Update()
     {
         cooldownTimer += Time.deltaTime;
         HandleCooldownUI();
+        shuriCountText.text = shuriCount.ToString();
 
-        if (Input.GetButton("Shuriken") && cooldownTimer >= cooldown)
+        if (Input.GetButton("Shuriken") && cooldownTimer >= cooldown && shuriCount > 0)
         {
             ThrowShuriken();
+            shuriCount--;
             cooldownTimer = 0f;
         }
     }

--- a/Unity Files/Assets/Scripts/Tutscript.cs
+++ b/Unity Files/Assets/Scripts/Tutscript.cs
@@ -4,10 +4,12 @@ using UnityEngine.Events;
 public class TutorialTrigger : MonoBehaviour
 {
     public UnityEvent onTriggered;
+    public GameObject Tutrat;
 
     public void Trigger()
     {
         onTriggered?.Invoke();
         Destroy(gameObject);
+        Tutrat.SetActive(false);
     }
 }

--- a/Unity Files/Assets/Scripts/Walkthrough.cs
+++ b/Unity Files/Assets/Scripts/Walkthrough.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 public enum TutorialStep
 {
     BasicAttack,
+    Charge,
     Jump,
+    Down,
     Dash,
     Shuriken,
     Complete
@@ -27,6 +29,8 @@ public class TutorialManager : MonoBehaviour
     public GameObject rat2;
     public GameObject rat3;
     public GameObject rat4;
+    public GameObject rat5;
+    public GameObject rat6;
     public GameObject startrat;
 
     void Awake()
@@ -39,23 +43,37 @@ public class TutorialManager : MonoBehaviour
         switch (currentStep)
         {
             case TutorialStep.BasicAttack:
-                platform1.SetActive(true);
+                //platform1.SetActive(true);
                 rat2.SetActive(true);
-                currentStep = TutorialStep.Jump;
+                currentStep = TutorialStep.Charge;
                 startrat.SetActive(false);
                 cameraShake.Shake();
                 break;
 
-            case TutorialStep.Jump:
-                platform2.SetActive(true);
+            case TutorialStep.Charge:
+                platform1.SetActive(true);
                 rat3.SetActive(true);
+                currentStep = TutorialStep.Jump;
+                cameraShake.Shake();
+                break;
+
+            case TutorialStep.Jump:
+                //platform2.SetActive(true);
+                rat4.SetActive(true);
+                currentStep = TutorialStep.Down;
+                cameraShake.Shake();
+                break;
+
+            case TutorialStep.Down:
+                platform2.SetActive(true);
+                rat5.SetActive(true);
                 currentStep = TutorialStep.Dash;
                 cameraShake.Shake();
                 break;
 
             case TutorialStep.Dash:
                 platform3.SetActive(true);
-                rat4.SetActive(true);
+                rat6.SetActive(true);
                 currentStep = TutorialStep.Shuriken;
                 cameraShake.Shake();
                 break;
@@ -64,7 +82,7 @@ public class TutorialManager : MonoBehaviour
                 platform3.SetActive(false);
                 platform2.SetActive(false);
                 platform1.SetActive(false);
-                rat4.SetActive(false);
+                rat6.SetActive(false);
                 startrat.SetActive(true);
                 // possibly could restart and set step back to start?
                 cameraShake.Shake();


### PR DESCRIPTION
### Summary:
Added ammo economy to shuriken attack and added steps for new abilities in tutorial
### Details:
- Added a shuri counter set to 3 to player
- Added ammo pickup that resets shuri counter to 3
- Shuri can only be thrown is ammo is >0 and degrades by 1 with each throw
- Same throwing cooldown also applies

- Added two more rats to tutorial for charge attack and downward attack
- Changed "Use J to attack" to "Use J or N to attack"
### Files Changed:
- All scene files (placed ammo pickups)
- Player suite prefab
- Created new prefab (shuriken ammo pickup)
- Tutorial scripts
### Other info: 
- Tutorial may be adjusted to look better in near future :P
### Checklist
- [x] The program compiles and runs
- [x] The program is free of bugs (to your knowledge)
- [x] Changes are properly documented (comments, etc)
- [x] Someone has been contacted to review changes
