### PR TITLE
Bleedthrough Fix

### DIFF
--- a/Unity Files/Assets/Materials/BossHealthBar.mat
+++ b/Unity Files/Assets/Materials/BossHealthBar.mat
@@ -56,7 +56,7 @@ Material:
     m_Floats:
     - _ColorMask: 15
     - _EnableExternalAlpha: 0
-    - _Fill: 1
+    - _Fill: 0
     - _QueueControl: 0
     - _QueueOffset: 0
     - _Softness: 0

--- a/Unity Files/Assets/Scenes/Desert.unity
+++ b/Unity Files/Assets/Scenes/Desert.unity
@@ -899,7 +899,7 @@ TilemapRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 3
   m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_ChunkCullingBounds: {x: 0.017241359, y: 0.017241359, z: 0}
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0
@@ -208249,7 +208249,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -209185,7 +209185,7 @@ TilemapRenderer:
   m_SortingLayer: 0
   m_SortingOrder: -1
   m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_ChunkCullingBounds: {x: 0.017241359, y: 0.017241359, z: 0}
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0
@@ -252154,7 +252154,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -254161,7 +254161,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0

--- a/Unity Files/Assets/Scenes/Forrest.unity
+++ b/Unity Files/Assets/Scenes/Forrest.unity
@@ -31512,8 +31512,8 @@ Transform:
   m_GameObject: {fileID: 987541743}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -32.7, y: -27.120003, z: 0}
-  m_LocalScale: {x: 100, y: 40, z: 1}
+  m_LocalPosition: {x: -32.0237, y: -27.120003, z: 0}
+  m_LocalScale: {x: 98.65, y: 40, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -44759,7 +44759,7 @@ TilemapRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 3
   m_ChunkSize: {x: 32, y: 32, z: 32}
-  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_ChunkCullingBounds: {x: 0.017241359, y: 0.017241359, z: 0}
   m_MaxChunkCount: 16
   m_MaxFrameAge: 16
   m_SortOrder: 0

--- a/Unity Files/Assets/Scenes/Forrest.unity
+++ b/Unity Files/Assets/Scenes/Forrest.unity
@@ -26468,8 +26468,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.49, y: 0.00000015274}
-  m_SizeDelta: {x: 11.939, y: 1.205}
+  m_AnchoredPosition: {x: 0.62, y: 0.00000015274}
+  m_SizeDelta: {x: 13.938, y: 1.205}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &618476530
 MonoBehaviour:
@@ -39927,8 +39927,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -309.4, y: -476.8}
-  m_SizeDelta: {x: -1477.9559, y: -940.876}
+  m_AnchoredPosition: {x: -309.08246, y: -476.8}
+  m_SizeDelta: {x: -1475.223, y: -940.876}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1655030265
 MonoBehaviour:

--- a/Unity Files/Assets/Scripts/EndTrigger.cs
+++ b/Unity Files/Assets/Scripts/EndTrigger.cs
@@ -39,8 +39,8 @@ public class DesertEndTriggerCheese : MonoBehaviour
 
     void Update()
     {
-        if (endStart && playerInRange) 
-        { 
+        if (endStart && playerInRange)
+        {
             if (Input.GetButton("Interact"))
             {
                 currentEatTime += Time.deltaTime;

--- a/Unity Files/Assets/Scripts/ScorpionBossHP.cs
+++ b/Unity Files/Assets/Scripts/ScorpionBossHP.cs
@@ -7,10 +7,10 @@ public class ScorpionBossHP : MonoBehaviour
     public BossUI BossUI;
     void Start()
     {
-        
+
     }
 
-    void OnTriggerEnter2D(Collider2D collision) 
+    void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.CompareTag("Player"))
         {

--- a/Unity Files/Assets/Sprites/DesertRock.aseprite.meta
+++ b/Unity Files/Assets/Sprites/DesertRock.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639089181946270620
+  platformSettingsDirtyTick: 639150388831106270
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/Dirt.aseprite.meta
+++ b/Unity Files/Assets/Sprites/Dirt.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639077443678049029
+  platformSettingsDirtyTick: 639150385769921001
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/Grass44.aseprite.meta
+++ b/Unity Files/Assets/Sprites/Grass44.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639065357796022748
+  platformSettingsDirtyTick: 639150385426251273
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/Void.aseprite.meta
+++ b/Unity Files/Assets/Sprites/Void.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639081743451147158
+  platformSettingsDirtyTick: 639150386887022447
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/redback.aseprite.meta
+++ b/Unity Files/Assets/Sprites/redback.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639125772788145207
+  platformSettingsDirtyTick: 639150389928304803
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/redback2.aseprite.meta
+++ b/Unity Files/Assets/Sprites/redback2.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639125776598225742
+  platformSettingsDirtyTick: 639150389973554084
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/redback3.aseprite.meta
+++ b/Unity Files/Assets/Sprites/redback3.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639125776816412003
+  platformSettingsDirtyTick: 639150390022994155
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/sand43.aseprite.meta
+++ b/Unity Files/Assets/Sprites/sand43.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639110858007379914
+  platformSettingsDirtyTick: 639150389332814481
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/sandback44.aseprite.meta
+++ b/Unity Files/Assets/Sprites/sandback44.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639110853296221485
+  platformSettingsDirtyTick: 639150389554857386
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/sewer back.aseprite.meta
+++ b/Unity Files/Assets/Sprites/sewer back.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639150120576667702
+  platformSettingsDirtyTick: 639150395706667477
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/topSand.aseprite.meta
+++ b/Unity Files/Assets/Sprites/topSand.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639089182796326610
+  platformSettingsDirtyTick: 639150394597982659
   textureAssetName: 
   singleSpriteImportData:
   - name: 

--- a/Unity Files/Assets/Sprites/underSandNoBone.aseprite.meta
+++ b/Unity Files/Assets/Sprites/underSandNoBone.aseprite.meta
@@ -36,7 +36,7 @@ ScriptedImporter:
     spriteMeshType: 1
     alignment: 0
     spritePivot: {x: 0.5, y: 0.5}
-    spritePixelsToUnits: 30
+    spritePixelsToUnits: 29
     spriteBorder: {x: 0, y: 0, z: 0, w: 0}
     spriteGenerateFallbackPhysicsShape: 0
     generateCubemap: 6
@@ -102,7 +102,7 @@ ScriptedImporter:
     generateIndividualEvents: 1
     generateSpriteAtlas: 1
   importFileNodeState: 1
-  platformSettingsDirtyTick: 639089182978838990
+  platformSettingsDirtyTick: 639150394677031985
   textureAssetName: 
   singleSpriteImportData:
   - name: 


### PR DESCRIPTION
### Summary:
Fixed bleedthrough issue on Level 2 and 3. 
Set cheese pickup on level 3 to triggers.

### Details:
Changed PPU on sprites temporarily until the sprites can be updated.

### Files Changed:
forest.unity
desert.unity
Assorted sprites

### Other info: 

### Checklist
- [x] The program compiles and runs
- [x] The program is free of bugs (to your knowledge)
- [x] Changes are properly documented (comments, etc)
- [x] Someone has been contacted to review changes
